### PR TITLE
Returning the expiry of IdP certs from parseMetadata function 

### DIFF
--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -105,13 +105,25 @@ const parseMetadata = async (idpMeta: string, validateOpts): Promise<Record<stri
            * -----END CERTIFICATE-----
            */
           if (X509Certificate.indexOf(BEGIN) != -1 && X509Certificate.indexOf(END) != -1) {
-            const { validTo } = new crypto.X509Certificate(X509Certificate);
+            const { validTo } = new crypto.X509Certificate(X509Certificate.trim());
+            ret.validTo = validTo;
+          } else if (X509Certificate.indexOf(BEGIN) == -1 && X509Certificate.indexOf(END) != -1) {
+            /**
+             * Prefixing -----BEGIN CERTIFICATE-----
+             */
+            const { validTo } = new crypto.X509Certificate(`${BEGIN}\n${X509Certificate.trim()}`);
+            ret.validTo = validTo;
+          } else if (X509Certificate.indexOf(BEGIN) != -1 && X509Certificate.indexOf(END) == -1) {
+            /**
+             * Suffixing -----END CERTIFICATE-----
+             */
+            const { validTo } = new crypto.X509Certificate(`${X509Certificate.trim()}\n${END}`);
             ret.validTo = validTo;
           } else {
             /**
              * Prefixing -----BEGIN CERTIFICATE----- and suffixing -----END CERTIFICATE-----
              */
-            const { validTo } = new crypto.X509Certificate(`${BEGIN}\n${X509Certificate}${END}`);
+            const { validTo } = new crypto.X509Certificate(`${BEGIN}\n${X509Certificate.trim()}\n${END}`);
             ret.validTo = validTo;
           }
         }

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,5 +1,6 @@
 import * as rambda from 'rambda';
 import thumbprint from 'thumbprint';
+import crypto from 'crypto';
 
 import xml2js from 'xml2js';
 
@@ -94,6 +95,8 @@ const parseMetadata = async (idpMeta: string, validateOpts): Promise<Record<stri
 
         if (X509Certificate) {
           ret.thumbprint = thumbprint.calculate(X509Certificate);
+          const { validTo } = new crypto.X509Certificate(X509Certificate);
+          ret.validTo = validTo;
         }
 
         if (ssoPostUrl) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boxyhq/saml20",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "SAML 2.0 token parser for Node.js",
   "keywords": [
     "SAML 2.0",

--- a/test/assets/mock-saml-metadata1.xml
+++ b/test/assets/mock-saml-metadata1.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://saml.example.com/entityid" validUntil="2026-06-22T18:39:53.000Z">
+  <IDPSSODescriptor WantAuthnRequestsSigned="false" errorURL="https://login.openathens.net/auth-error?error=ERRORURL_CODE&ts=ERRORURL_TS&context=ERRORURL_CTX&transaction=ERRORURL_TID&sp=ERRORURL_RP" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>-----BEGIN CERTIFICATE-----
+MIICmDCCAYACCQC6LM978TM/gjANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJJ
+bjAgFw0yMjA0MTExMDI3MjBaGA8zMDIxMDgxMjEwMjcyMFowDTELMAkGA1UEBhMC
+SW4wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDgPMN71V4y5VzLw6Ev
+aQA+oMLzmIpoV/p4Y3AM00FUYbVhVtngvRPCmsKOvIxkTM9kZ6VjVfPmzQet+dDS
++rOmJDH5Y+42du6dJnA0SM/wNWL7nAqfWN6e7q7/Jxa/dYMOhkgV6/7+0jBxHGnn
+x/2CEVeDF5+nPsdDh2HlPy0MCXLjXGvRpHB/IHQsUHJFKuOQzTiz1OMQHLnV+FQX
+T2kDsGmbM/wZo6xGeH5qcRqZJGgLvtLj8XNe6yVmb1naog7Fr7gjThMichkNDVg2
+0/lkxYqIL8zgS2NYXwQ6UOKplUv189kHSbXgQCco0h1oNR2LRTaHoYsRnzLMH2Pv
+jVoTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMXKnzYEyLFwePXXWE76lq5S+2O2
+JIMtygzB3YxOJwvIFWmwDPxqpr4aOpw6T2pQLa3rM1YjW2roNw7B3HHXWoc9F4Av
+GAe8T1u0Cu+Tyo8ZFf9VrPg5kZ7x2G+nojFfs8zeuEKdNrUZz4bkgkC7sTWHFsOA
+oZjUqLyT2tfLnXfYGiXd0qGg9X1bs1x+anAhViltjZ97Eeq8wPtRqhm1hiQyawKT
+5qs4oKw0AaKsW4pBQux4h+ZmfvqD+1chBd5Ve/bq9FsEnWNkGyawzmsMSTB9UwDA
++bqiHmfaTXWlQnualNaY3g5v7EDVB4COz6rXXQY/y5Y90BFoho5MqIjGW0I=
+-----END CERTIFICATE-----</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:4000/api/saml/sso"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:4000/api/saml/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>

--- a/test/assets/mock-saml-metadata2.xml
+++ b/test/assets/mock-saml-metadata2.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://saml.example.com/entityid" validUntil="2026-06-22T18:39:53.000Z">
+  <IDPSSODescriptor WantAuthnRequestsSigned="false" errorURL="https://login.openathens.net/auth-error?error=ERRORURL_CODE&ts=ERRORURL_TS&context=ERRORURL_CTX&transaction=ERRORURL_TID&sp=ERRORURL_RP" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>MIICmDCCAYACCQC6LM978TM/gjANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJJ
+bjAgFw0yMjA0MTExMDI3MjBaGA8zMDIxMDgxMjEwMjcyMFowDTELMAkGA1UEBhMC
+SW4wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDgPMN71V4y5VzLw6Ev
+aQA+oMLzmIpoV/p4Y3AM00FUYbVhVtngvRPCmsKOvIxkTM9kZ6VjVfPmzQet+dDS
++rOmJDH5Y+42du6dJnA0SM/wNWL7nAqfWN6e7q7/Jxa/dYMOhkgV6/7+0jBxHGnn
+x/2CEVeDF5+nPsdDh2HlPy0MCXLjXGvRpHB/IHQsUHJFKuOQzTiz1OMQHLnV+FQX
+T2kDsGmbM/wZo6xGeH5qcRqZJGgLvtLj8XNe6yVmb1naog7Fr7gjThMichkNDVg2
+0/lkxYqIL8zgS2NYXwQ6UOKplUv189kHSbXgQCco0h1oNR2LRTaHoYsRnzLMH2Pv
+jVoTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMXKnzYEyLFwePXXWE76lq5S+2O2
+JIMtygzB3YxOJwvIFWmwDPxqpr4aOpw6T2pQLa3rM1YjW2roNw7B3HHXWoc9F4Av
+GAe8T1u0Cu+Tyo8ZFf9VrPg5kZ7x2G+nojFfs8zeuEKdNrUZz4bkgkC7sTWHFsOA
+oZjUqLyT2tfLnXfYGiXd0qGg9X1bs1x+anAhViltjZ97Eeq8wPtRqhm1hiQyawKT
+5qs4oKw0AaKsW4pBQux4h+ZmfvqD+1chBd5Ve/bq9FsEnWNkGyawzmsMSTB9UwDA
++bqiHmfaTXWlQnualNaY3g5v7EDVB4COz6rXXQY/y5Y90BFoho5MqIjGW0I=
+-----END CERTIFICATE-----</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:4000/api/saml/sso"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:4000/api/saml/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>

--- a/test/assets/mock-saml-metadata3.xml
+++ b/test/assets/mock-saml-metadata3.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://saml.example.com/entityid" validUntil="2026-06-22T18:39:53.000Z">
+  <IDPSSODescriptor WantAuthnRequestsSigned="false" errorURL="https://login.openathens.net/auth-error?error=ERRORURL_CODE&ts=ERRORURL_TS&context=ERRORURL_CTX&transaction=ERRORURL_TID&sp=ERRORURL_RP" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <KeyDescriptor use="signing">
+      <KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+        <X509Data>
+          <X509Certificate>-----BEGIN CERTIFICATE-----
+MIICmDCCAYACCQC6LM978TM/gjANBgkqhkiG9w0BAQsFADANMQswCQYDVQQGEwJJ
+bjAgFw0yMjA0MTExMDI3MjBaGA8zMDIxMDgxMjEwMjcyMFowDTELMAkGA1UEBhMC
+SW4wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDgPMN71V4y5VzLw6Ev
+aQA+oMLzmIpoV/p4Y3AM00FUYbVhVtngvRPCmsKOvIxkTM9kZ6VjVfPmzQet+dDS
++rOmJDH5Y+42du6dJnA0SM/wNWL7nAqfWN6e7q7/Jxa/dYMOhkgV6/7+0jBxHGnn
+x/2CEVeDF5+nPsdDh2HlPy0MCXLjXGvRpHB/IHQsUHJFKuOQzTiz1OMQHLnV+FQX
+T2kDsGmbM/wZo6xGeH5qcRqZJGgLvtLj8XNe6yVmb1naog7Fr7gjThMichkNDVg2
+0/lkxYqIL8zgS2NYXwQ6UOKplUv189kHSbXgQCco0h1oNR2LRTaHoYsRnzLMH2Pv
+jVoTAgMBAAEwDQYJKoZIhvcNAQELBQADggEBAMXKnzYEyLFwePXXWE76lq5S+2O2
+JIMtygzB3YxOJwvIFWmwDPxqpr4aOpw6T2pQLa3rM1YjW2roNw7B3HHXWoc9F4Av
+GAe8T1u0Cu+Tyo8ZFf9VrPg5kZ7x2G+nojFfs8zeuEKdNrUZz4bkgkC7sTWHFsOA
+oZjUqLyT2tfLnXfYGiXd0qGg9X1bs1x+anAhViltjZ97Eeq8wPtRqhm1hiQyawKT
+5qs4oKw0AaKsW4pBQux4h+ZmfvqD+1chBd5Ve/bq9FsEnWNkGyawzmsMSTB9UwDA
++bqiHmfaTXWlQnualNaY3g5v7EDVB4COz6rXXQY/y5Y90BFoho5MqIjGW0I=
+</X509Certificate>
+        </X509Data>
+      </KeyInfo>
+    </KeyDescriptor>
+    <NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</NameIDFormat>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="http://localhost:4000/api/saml/sso"/>
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="http://localhost:4000/api/saml/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>

--- a/test/lib/metadata.spec.ts
+++ b/test/lib/metadata.spec.ts
@@ -4,9 +4,11 @@ import fs from 'fs';
 
 const samlMetadata = fs.readFileSync('./test/assets/mock-saml-metadata.xml').toString();
 const samlMetadata1 = fs.readFileSync('./test/assets/mock-saml-metadata1.xml').toString();
+const samlMetadata2 = fs.readFileSync('./test/assets/mock-saml-metadata2.xml').toString();
+const samlMetadata3 = fs.readFileSync('./test/assets/mock-saml-metadata3.xml').toString();
 
 describe('metadata.ts', function () {
-  it('saml MetaData ok', async function () {
+  it('saml MetaData ok without BEGIN & END notations', async function () {
     const value = await parseMetadata(samlMetadata, {});
     expect(value.entityID).to.equal('https://saml.example.com/entityid');
     expect(value.thumbprint).to.equal('8996bcc1afff3ff8e41f8025ff034b516050a434');
@@ -18,6 +20,26 @@ describe('metadata.ts', function () {
 
   it('saml MetaData ok with cert having BEGIN & END notations', async function () {
     const value = await parseMetadata(samlMetadata1, {});
+    expect(value.entityID).to.equal('https://saml.example.com/entityid');
+    expect(value.thumbprint).to.equal('f9e424fe5fb3422db37859fe29b7f92f11af60a7');
+    expect(value.loginType).to.equal('idp');
+    expect(value.sso.postUrl).to.equal('http://localhost:4000/api/saml/sso');
+    expect(value.sso.redirectUrl).to.equal('http://localhost:4000/api/saml/sso');
+    expect(value.validTo).to.equal('Aug 12 10:27:20 3021 GMT');
+  });
+
+  it('saml MetaData ok with cert having just END notations', async function () {
+    const value = await parseMetadata(samlMetadata2, {});
+    expect(value.entityID).to.equal('https://saml.example.com/entityid');
+    expect(value.thumbprint).to.equal('8996bcc1afff3ff8e41f8025ff034b516050a434');
+    expect(value.loginType).to.equal('idp');
+    expect(value.sso.postUrl).to.equal('http://localhost:4000/api/saml/sso');
+    expect(value.sso.redirectUrl).to.equal('http://localhost:4000/api/saml/sso');
+    expect(value.validTo).to.equal('Aug 12 10:27:20 3021 GMT');
+  });
+
+  it('saml MetaData ok with cert having just BEGIN notations', async function () {
+    const value = await parseMetadata(samlMetadata3, {});
     expect(value.entityID).to.equal('https://saml.example.com/entityid');
     expect(value.thumbprint).to.equal('f9e424fe5fb3422db37859fe29b7f92f11af60a7');
     expect(value.loginType).to.equal('idp');

--- a/test/lib/metadata.spec.ts
+++ b/test/lib/metadata.spec.ts
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import fs from 'fs';
 
 const samlMetadata = fs.readFileSync('./test/assets/mock-saml-metadata.xml').toString();
+const samlMetadata1 = fs.readFileSync('./test/assets/mock-saml-metadata1.xml').toString();
 
 describe('metadata.ts', function () {
   it('saml MetaData ok', async function () {
@@ -12,6 +13,17 @@ describe('metadata.ts', function () {
     expect(value.loginType).to.equal('idp');
     expect(value.sso.postUrl).to.equal('http://localhost:4000/api/saml/sso');
     expect(value.sso.redirectUrl).to.equal('http://localhost:4000/api/saml/sso');
+    expect(value.validTo).to.equal('Aug 12 10:27:20 3021 GMT');
+  });
+
+  it('saml MetaData ok with cert having BEGIN & END notations', async function () {
+    const value = await parseMetadata(samlMetadata1, {});
+    expect(value.entityID).to.equal('https://saml.example.com/entityid');
+    expect(value.thumbprint).to.equal('f9e424fe5fb3422db37859fe29b7f92f11af60a7');
+    expect(value.loginType).to.equal('idp');
+    expect(value.sso.postUrl).to.equal('http://localhost:4000/api/saml/sso');
+    expect(value.sso.redirectUrl).to.equal('http://localhost:4000/api/saml/sso');
+    expect(value.validTo).to.equal('Aug 12 10:27:20 3021 GMT');
   });
 
   it('saml Metadata validateNameIDFormat ok', async function () {


### PR DESCRIPTION
We need the expiry i.e. validTo of the X509 cert received from IdP.
The parseMetadata function has been modified to find and return the validTo of the X509 certificate.