### PR TITLE
Accept either cert or thumbprint in validate

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,13 +17,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           always-auth: true
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,7 +33,9 @@ jobs:
       - run: npm i
       - run: npm run lint
       - run: npm run build
-      - run: npm run test
+      - run: |
+          export NODE_OPTIONS=--max_old_space_size=4096
+          npm run test
       - name: Publish NPM
         if: github.ref == 'refs/heads/release' || contains(github.ref, 'refs/tags/beta-v')
         run: |

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -93,6 +93,12 @@ const validateInternal = async (rawAssertion, options, cb) => {
     cb(new Error('publicKey or thumbprint are options required.'));
     return;
   }
+
+  if (options.publicKey && options.thumbprint) {
+    cb(new Error('You should provide either cert or certThumbprint, not both'));
+    return;
+  }
+
   let decAssertion = false;
   try {
     const { assertion, decrypted } = decryptXml(rawAssertion, options);

--- a/lib/validateSignature.ts
+++ b/lib/validateSignature.ts
@@ -79,19 +79,23 @@ const hasValidSignature = (xml, cert, certThumbprint) => {
 };
 
 const validateSignature = (xml, cert, certThumbprint) => {
+  if (cert && certThumbprint) {
+    throw new Error('You should provide either cert or certThumbprint, not both');
+  }
+
   const { valid, calculatedThumbprint, id } = hasValidSignature(xml, cert, certThumbprint);
 
   if (valid) {
-    if (cert) {
-      return id;
-    }
-
     if (certThumbprint) {
       const thumbprints = certThumbprint.split(',');
 
       if (thumbprints.includes(calculatedThumbprint)) {
         return id;
       }
+    }
+
+    if (cert) {
+      return id;
     }
   }
 };

--- a/test/lib/decrypt.response.spec.ts
+++ b/test/lib/decrypt.response.spec.ts
@@ -8,7 +8,7 @@ const oneLoginSamlResponseEncrypted = fs
 const oneLoginPrivateKey = fs.readFileSync('./test/assets/certificates/oneloginPrivateKey.pem').toString();
 const oneLoginThumbprint = '56d68c4616d0909ac25dade25c36a7bd792eaf62';
 const oneLoginInResponseTo = '_25b63bdecac84d524aec';
-const oneLoginCertificate = fs.readFileSync('./test/assets/certificates/oneloginPublicKey.crt').toString();
+// const oneLoginCertificate = fs.readFileSync('./test/assets/certificates/oneloginPublicKey.crt').toString();
 const oneLoginIssuerName = 'https://app.onelogin.com/saml/metadata/2f5926c1-a571-4702-9ed5-12309c86f9c7';
 const oneLoginProfileClaims = 'hojit22291@abincol.com';
 
@@ -18,7 +18,7 @@ const oktaSamlResponseEncrypted = fs
 const oktaPrivateKey = fs.readFileSync('./test/assets/certificates/oktaPrivateKey.pem').toString();
 const oktaThumbprint = '008c1aa2ed3cdb5c064c99b3d1619346b619008a';
 const oktaInResponseTo = '_f81f46f19ccf489ab1a1';
-const oktaCertificate = fs.readFileSync('./test/assets/certificates/oktaPublicKey.crt').toString();
+// const oktaCertificate = fs.readFileSync('./test/assets/certificates/oktaPublicKey.crt').toString();
 const oktaIssuerName = 'http://www.okta.com/exkymhf9ve6PI9KfY696';
 const oktaProfileClaims = 'hojit22291@abincol.com';
 

--- a/test/lib/decrypt.response.spec.ts
+++ b/test/lib/decrypt.response.spec.ts
@@ -26,7 +26,6 @@ describe('decrypt.response.spec', function () {
   it('One Login Should validate saml 2.0 token using thumbprint', async function () {
     const response = await validate(oneLoginSamlResponseEncrypted, {
       privateKey: oneLoginPrivateKey,
-      publicKey: oneLoginCertificate,
       thumbprint: oneLoginThumbprint,
       bypassExpiration: true,
       inResponseTo: oneLoginInResponseTo,
@@ -54,7 +53,6 @@ describe('decrypt.response.spec', function () {
   it('Okta Should validate saml 2.0 token using thumbprint', async function () {
     const response = await validate(oktaSamlResponseEncrypted, {
       privateKey: oktaPrivateKey,
-      publicKey: oktaCertificate,
       thumbprint: oktaThumbprint,
       bypassExpiration: true,
       inResponseTo: oktaInResponseTo,

--- a/test/lib/saml20.response.spec.ts
+++ b/test/lib/saml20.response.spec.ts
@@ -16,7 +16,6 @@ const inResponseTo = 'ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685';
 describe('lib.saml20.response', function () {
   it('Should validate saml 2.0 token using thumbprint', async function () {
     const response = await validate(validResponse, {
-      publicKey: certificate,
       thumbprint: thumbprint,
       bypassExpiration: true,
       inResponseTo: inResponseTo,

--- a/test/lib/saml20.responseSignedMessage.spec.ts
+++ b/test/lib/saml20.responseSignedMessage.spec.ts
@@ -15,7 +15,6 @@ const inResponseTo = 'ONELOGIN_4fee3b046395c4e751011e97f8900b5273d56685';
 describe('saml20.responseSignedMessage', function () {
   it('Should validate saml 2.0 token using thumbprint', async function () {
     const response = await validate(validResponse, {
-      publicKey: certificate,
       thumbprint: thumbprint,
       bypassExpiration: true,
       inResponseTo: inResponseTo,


### PR DESCRIPTION
But not both to ensure validation orders cannot be bypassed accidentally. Doesn't affect usage in Jackson since only thumbprint is used there.