### PR TITLE
Ensure form post is escaped

### DIFF
--- a/lib/post.ts
+++ b/lib/post.ts
@@ -1,6 +1,15 @@
+const escapeHtml = (unsafeHtml: string) => {
+  return unsafeHtml
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 const createPostForm = (postUrl: string, params: { name: string; value: string }[]) => {
   const parr = (params || []).map(({ name, value }) => {
-    return `<input type="hidden" name="${name}" value="${value.replace(/"/g, '&quot;')}"/>`;
+    return `<input type="hidden" name="${name}" value="${escapeHtml(value)}"/>`;
   });
 
   const formElements = [

--- a/lib/post.ts
+++ b/lib/post.ts
@@ -1,6 +1,6 @@
 const createPostForm = (postUrl: string, params: { name: string; value: string }[]) => {
   const parr = (params || []).map(({ name, value }) => {
-    return `<input type="hidden" name="${name}" value="${value}"/>`;
+    return `<input type="hidden" name="${name}" value="${value.replace(/"/g, '&quot;')}"/>`;
   });
 
   const formElements = [


### PR DESCRIPTION
Currently if the RelayState contains double quotes, the createFormPost method will copy that directly to the HTML, resulting in something along the lines of: `<input type="hidden" name="RelayState" value="{"someProperty":"someValue"}"/>`, which will result in invalid RelayState of `{` being posted to the ACS endpoint. This PR replace instances of `"` in the RelayState with `&quot;` so that the RelayState sent to the ACS is accurate.