### PR TITLE
Fix destructing logout response before error checking in parseLogoutResponse

### DIFF
--- a/lib/logout.ts
+++ b/lib/logout.ts
@@ -15,11 +15,12 @@ const parseLogoutResponse = async (
     xml2js.parseString(
       rawResponse,
       { tagNameProcessors: [xml2js.processors.stripPrefix] },
-      (err: Error | null, { LogoutResponse }) => {
+      (err: Error | null, parsedData: { LogoutResponse: any }) => {
         if (err) {
           reject(err);
           return;
         }
+        const { LogoutResponse } = parsedData;
 
         resolve({
           issuer: LogoutResponse.Issuer[0]._,

--- a/test/lib/logout.spec.ts
+++ b/test/lib/logout.spec.ts
@@ -4,6 +4,7 @@ import { parseLogoutResponse, createLogoutRequest } from '../../lib/logout';
 
 const response = fs.readFileSync('./test/assets/logout-response.xml').toString();
 const responseFailed = fs.readFileSync('./test/assets/logout-response-failed.xml').toString();
+const responseInvalid = 'invalid_data';
 
 describe('logout.ts', function () {
   it('response ok', async function () {
@@ -33,5 +34,17 @@ describe('logout.ts', function () {
 
     assert.strictEqual(!!req.id, true);
     assert.strictEqual(!!req.xml, true);
+  });
+
+  it('should throw an expected error for response containing invalid xml', async function () {
+    await assert.rejects(
+      async () => {
+        await parseLogoutResponse(responseInvalid);
+      },
+      (error: any) => {
+        assert.strictEqual(error.message.includes('Non-whitespace before first tag'), true);
+        return true;
+      }
+    );
   });
 });


### PR DESCRIPTION
Fixes #744 